### PR TITLE
fix test depending on local timezone

### DIFF
--- a/test/holidays.js
+++ b/test/holidays.js
@@ -14,9 +14,15 @@ exports['holidays.on finds Labour Day in .ca'] = function(test) {
 
     test.ok(result);
     test.equals(result.length, 1);
-    test.equals(result[0].date.toDateString(), 'Mon Sep 01 2008');
-    test.equals(result[0].date.valueOf(), 1220184000000);
-
+    var date = result[0].date;
+    test.equals(date.toDateString(), 'Mon Sep 01 2008');
+    test.equals(date.getFullYear(), 2008);
+    test.equals(date.getMonth(), 8);
+    test.equals(date.getDay(), 1);
+    test.equals(date.getHours(), 0);
+    test.equals(date.getMinutes(), 0);
+    test.equals(date.getSeconds(), 0);
+    test.equals(date.getMilliseconds(), 0);
     test.done();
 };
 


### PR DESCRIPTION
When running npm test it failed with

```
✖ holidays.on finds Labour Day in .ca

AssertionError: 1220220000000 == 1220184000000
    at Object.equals (/home/bastian/projekte/forked/liberty/node_modules/nodeunit/lib/types.js:83:39)
    at Object.exports.holidays.on finds Labour Day in .ca (/home/bastian/projekte/forked/liberty/test/holidays.js:18:10)
    at Object.<anonymous> (/home/bastian/projekte/forked/liberty/node_modules/nodeunit/lib/core.js:236:16)
    at /home/bastian/projekte/forked/liberty/node_modules/nodeunit/lib/core.js:236:16
    at Object.exports.runTest (/home/bastian/projekte/forked/liberty/node_modules/nodeunit/lib/core.js:70:9)
    at /home/bastian/projekte/forked/liberty/node_modules/nodeunit/lib/core.js:118:25
    at /home/bastian/projekte/forked/liberty/node_modules/nodeunit/deps/async.js:513:13
    at iterate (/home/bastian/projekte/forked/liberty/node_modules/nodeunit/deps/async.js:123:13)
    at /home/bastian/projekte/forked/liberty/node_modules/nodeunit/deps/async.js:134:25
    at /home/bastian/projekte/forked/liberty/node_modules/nodeunit/deps/async.js:515:17
```

My guess is that this is because the expectation `test.equals(result[0].date.valueOf(), 1220184000000);`, or more specifically `date.valueOf()` on a JavaScript date depends on the local timezone of the machine where the test is executed.

The millis from your expectation are actually 2008-08-31T12:00:00.000Z and the value that I got from `date.valueOf()` represents 2008-08-31T22:00:00.000Z. 

"My" value is midnight of 1st September GMT in my timezone (+2), "your" value is maybe midnight 1st September UTC in your timezone, if that timezone is +12 -- you're from NZ, right?

---

Off topic: You might wonder why I'm digging into this, here's why: I'd like to use [workwork](https://github.com/wombleton/workwork) for a project of mine and for that I'd need to add more countries to liberty, especially Germany - would you accept pull requests for that?
