### PR TITLE
Add rules for German holidays

### DIFF
--- a/data/de.yaml
+++ b/data/de.yaml
@@ -1,0 +1,58 @@
+# German holiday definitions
+#
+# Copied from the Ruby Holiday gem (https://github.com/alexdunae/holidays/blob/master/data/de.yaml) on 2015-04-19.
+#
+# Updated: 2009-11-05.
+# Sources:
+# - http://en.wikipedia.org/wiki/Holidays_in_Germany
+# - http://www.timeanddate.com/calendar/index.html?country=8
+# - http://www.germany.info/relaunch/welcome/travel/holidays.html
+
+- name: Neujahrstag
+  regions: [de]
+  rule: FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1
+- name: Heilige Drei Könige
+  regions: [de_bw, de_by, de_st]
+  rule: FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=6
+- name: Karfreitag
+  regions: [de]
+  rule: BYEASTER=-2
+- name: Ostermontag
+  regions: [de]
+  rule: BYEASTER=1
+- name: Tag der Arbeit
+  regions: [de]
+  rule: FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=1
+- name: Christi Himmelfahrt
+  regions: [de]
+  rule: BYEASTER=39
+- name: Pfingstmontag
+  regions: [de]
+  rule: BYEASTER=50
+- name: Fronleichnam
+  regions: [de_bw, de_by, de_he, de_nw, de_rp, de_sl]
+  rule: BYEASTER=60
+- name: Mariä Himmelfahrt
+  regions: [de_by, de_sl]
+  rule: FREQ=YEARLY;BYMONTH=8;BYMONTHDAY=15
+- name: Tag der Deutschen Einheit
+  regions: [de]
+  rule: FREQ=YEARLY;BYMONTH=10;BYMONTHDAY=3
+- name: Reformationstag
+  regions: [de_bb, de_mv, de_sn, de_st, de_th]
+  rule: FREQ=YEARLY;BYMONTH=10;BYMONTHDAY=31
+- name: Allerheiligen
+  regions: [de_bw, de_by, de_nw, de_rp, de_sl]
+  rule: FREQ=YEARLY;BYMONTH=11;BYMONTHDAY=1
+# repentance day (Buß- und Bettag) is on the last Wednesday before November 23rd
+# That could be expressed as BYYEARDAY=320,...,326;BDAY=WE but this does not
+# hold in leap years, so we go backwards from 31.12.
+- name: Buß- und Bettag
+  regions: [de_sn]
+  rule: FREQ=YEARLY;BYYEARDAY=-46,-45,-44,-43,-42,-41,-40;BYDAY=WE
+- name: 1. Weihnachtstag
+  regions: [de]
+  rule: FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=25
+- name: 2. Weihnachtstag
+  regions: [de]
+  rule: FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=26

--- a/test/de.js
+++ b/test/de.js
@@ -1,0 +1,136 @@
+var _ = require('underscore'),
+    moment = require('moment'),
+    Liberty = require('..'),
+    holidays;
+
+exports['national holidays'] = function(test) {
+    holidays = new Liberty('de');
+    var values = _.zip([
+        '2009-01-01',
+        '2009-04-10',
+        '2009-04-13',
+        '2009-05-01',
+        '2009-05-21',
+        '2009-06-01',
+        '2009-10-03',
+        '2009-12-25',
+        '2009-12-26',
+    ], [
+        'Neujahrstag',
+        'Karfreitag',
+        'Ostermontag',
+        'Tag der Arbeit',
+        'Christi Himmelfahrt',
+        'Pfingstmontag',
+        'Tag der Deutschen Einheit',
+        '1. Weihnachtstag',
+        '2. Weihnachtstag',
+    ]);
+    compareEach(values, test);
+    compareNegative('2010-05-08', 'Whatever-Day', test);
+    test.done();
+};
+
+exports['regional holidays'] = function(test) {
+    checkRegional({
+        regions: ['de_bw', 'de_by', 'de_st'],
+        regionsNot: ['de_be', 'de_hb', 'de_hh', 'de_ni', 'de_sh'],
+        date: '2009-01-06',
+        name: 'Heilige Drei Könige',
+    }, test);
+    checkRegional({
+        regions: ['de_bw', 'de_by', 'de_he', 'de_nw', 'de_rp', 'de_sl'],
+        regionsNot: ['de_be', 'de_hb', 'de_hh', 'de_ni', 'de_sh'],
+        date: '2009-06-11',
+        name: 'Fronleichnam',
+    }, test);
+    checkRegional({
+        regions: ['de_by', 'de_sl'],
+        regionsNot: ['de_be', 'de_hb', 'de_hh', 'de_ni', 'de_sh'],
+        date: '2009-08-15',
+        name: 'Mariä Himmelfahrt',
+    }, test);
+    checkRegional({
+        regions: ['de_bb', 'de_mv', 'de_sn', 'de_st', 'de_th'],
+        regionsNot: ['de_be', 'de_hb', 'de_hh', 'de_ni', 'de_sh'],
+        date: '2009-10-31',
+        name: 'Reformationstag',
+    }, test);
+    checkRegional({
+        regions: ['de_bw', 'de_by', 'de_nw', 'de_rp', 'de_sl'],
+        regionsNot: ['de_be', 'de_hb', 'de_hh', 'de_ni', 'de_sh'],
+        date: '2009-11-01',
+        name: 'Allerheiligen',
+    }, test);
+    test.done();
+};
+
+exports['repentance day in saxony'] = function(test) {
+    // repentance day (Buß- und Bettag) gets its own test because it has a quite
+    // peculiar recurrence rule, it is the last Wednesday before
+    // November 23.
+    holidays = new Liberty('de_sn');
+    var values = _.zip([
+        '2004-11-17',
+        '2005-11-16',
+        '2006-11-22',
+        '2007-11-21',
+        '2008-11-19',
+        '2009-11-18',
+        '2010-11-17',
+        '2011-11-16',
+        '2012-11-21',
+        '2013-11-20',
+        '2014-11-19',
+        '2015-11-18',
+        '2016-11-16',
+        '2017-11-22',
+        '2018-11-21',
+        '2019-11-20',
+        '2020-11-18',
+        '2021-11-17',
+        '2022-11-16',
+        '2023-11-22',
+        '2024-11-20',
+    ], fillArray(21, 'Buß- und Bettag'));
+    compareEach(values, test);
+    test.done();
+};
+
+function compareEach(pairs, test) {
+    _.each(pairs, function(pair) {
+        comparePositive(pair[0], pair[1], test);
+    });
+}
+
+function comparePositive(date, name, test) {
+    var date = moment(date);
+    var holidayDate = holidays.on(date)[0];
+    test.ok(!!holidayDate, 'There should be a public holiday (' + name +
+        ') on ' + date.format() + ' in region \'' + holidays.locales + '\'.');
+    if (holidayDate) {
+        test.equals(holidayDate.name, name);
+    }
+}
+
+function compareNegative(date, name, test) {
+    date = moment(date);
+    var holidayDate = holidays.on(date)[0];
+    test.ok(!holidayDate, name + ' (' + date.format() + ') is not a ' +
+            'public holiday in region \'' + holidays.locales + '\'.');
+}
+
+function checkRegional(config, test) {
+    config.regions.forEach(function(region) {
+        holidays = new Liberty(region);
+        comparePositive(config.date, config.name, test);
+    });
+    config.regionsNot.forEach(function(region) {
+        holidays = new Liberty(region);
+        compareNegative(config.date, config.name, test);
+    });
+}
+
+function fillArray(n, value) {
+    return Array.apply(null, new Array(n)).map(function() { return value; });
+}

--- a/test/holidays.js
+++ b/test/holidays.js
@@ -14,9 +14,15 @@ exports['holidays.on finds Labour Day in .ca'] = function(test) {
 
     test.ok(result);
     test.equals(result.length, 1);
-    test.equals(result[0].date.toDateString(), 'Mon Sep 01 2008');
-    test.equals(result[0].date.valueOf(), 1220184000000);
-
+    var date = result[0].date;
+    test.equals(date.toDateString(), 'Mon Sep 01 2008');
+    test.equals(date.getFullYear(), 2008);
+    test.equals(date.getMonth(), 8);
+    test.equals(date.getDay(), 1);
+    test.equals(date.getHours(), 0);
+    test.equals(date.getMinutes(), 0);
+    test.equals(date.getSeconds(), 0);
+    test.equals(date.getMilliseconds(), 0);
     test.done();
 };
 


### PR DESCRIPTION
This is a full port of the German rules from Alex Dunae's holidays gem, including all tests.

Unfortunately, this PR is not entirely clean, in addition to the German rules it also already contains the test fix from #1, as I needed a working test suite to start of. In practice, this should not be a problem, I think.
