### PR TITLE
Accept array or varargs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@ var _ = require('underscore'),
     liberty = require('./liberty');
 
 module.exports = function() {
-    this.locales = _.toArray(arguments);
-
+    if (arguments.length === 1 && _.isArray(arguments[0])) {
+        // use first (and only) argument as the array of locales
+        this.locales = _.toArray(arguments[0]);
+    } else {
+        // use variable length argument list as locales array
+        this.locales = _.toArray(arguments);
+    }
     _.extend(this, liberty);
 };

--- a/test/holidays.js
+++ b/test/holidays.js
@@ -14,9 +14,15 @@ exports['holidays.on finds Labour Day in .ca'] = function(test) {
 
     test.ok(result);
     test.equals(result.length, 1);
-    test.equals(result[0].date.toDateString(), 'Mon Sep 01 2008');
-    test.equals(result[0].date.valueOf(), 1220184000000);
-
+    var date = result[0].date;
+    test.equals(date.toDateString(), 'Mon Sep 01 2008');
+    test.equals(date.getFullYear(), 2008);
+    test.equals(date.getMonth(), 8);
+    test.equals(date.getDay(), 1);
+    test.equals(date.getHours(), 0);
+    test.equals(date.getMinutes(), 0);
+    test.equals(date.getSeconds(), 0);
+    test.equals(date.getMilliseconds(), 0);
     test.done();
 };
 

--- a/test/holidays.js
+++ b/test/holidays.js
@@ -52,3 +52,11 @@ exports['multiple locales works'] = function(test) {
     test.equals(result.length, 2);
     test.done();
 };
+
+exports['multiple locales work with array'] = function(test) {
+    var holidays = new Holidays(['ca_ab', 'ca_ns']),
+        result = holidays.on(moment('2008-08-04'));
+
+    test.equals(result.length, 2);
+    test.done();
+};


### PR DESCRIPTION
The exported function in `index.js` currently only works with variable length list of regions (that is, you need to call it like `new Liberty('nz', 'nz_sl')`. If you call it with an array of locales as the parameter like  `new Liberty(['nz', 'nz_sl'])` it will not work because it will just wrap the array in another array, leaving `this.locales` = `[['nz', 'nz_sl']]`.

This PR fixes this.

If I understand things correctly, this fix is needed because one sometimes needs to be able to pass multiple locales/jurisdictions into workwork and have workwork pass them on to liberty. I will create a follow up PR for workwork to enable passing multiple locales there.
